### PR TITLE
Namespaces shouldn't end with a semicolon

### DIFF
--- a/imgui_sdl.cpp
+++ b/imgui_sdl.cpp
@@ -162,7 +162,7 @@ namespace
 
 		// Uniform color is identified by its color and the coordinates of the edges.
 		using UniformColorTriangleKey = std::tuple<uint32_t, int, int, int, int, int, int>;
-		// The generic triangle cache unfortunately has to be basically a full representation of the triangle. 
+		// The generic triangle cache unfortunately has to be basically a full representation of the triangle.
 		// This includes the (offset) vertex positions, texture coordinates and vertex colors.
 		using GenericTriangleVertexKey = std::tuple<int, int, double, double, uint32_t>;
 		using GenericTriangleKey = std::tuple<GenericTriangleVertexKey, GenericTriangleVertexKey, GenericTriangleVertexKey>;
@@ -597,7 +597,7 @@ namespace ImGuiSDL
 						const bool doesTriangleUseOnlyColor = bounding.UsesOnlyColor();
 
 						// Actually, since we render a whole bunch of rectangles, we try to first detect those, and render them more efficiently.
-						// How are rectangles detected? It's actually pretty simple: If all 6 vertices lie on the extremes of the bounding box, 
+						// How are rectangles detected? It's actually pretty simple: If all 6 vertices lie on the extremes of the bounding box,
 						// it's a rectangle.
 						if (i + 6 <= drawCommand->ElemCount)
 						{
@@ -657,4 +657,4 @@ namespace ImGuiSDL
 
 		SDL_SetRenderDrawBlendMode(CurrentDevice->Renderer, blendMode);
 	}
-};
+}

--- a/imgui_sdl.h
+++ b/imgui_sdl.h
@@ -14,4 +14,4 @@ namespace ImGuiSDL
 	// Call this every frame after ImGui::Render with ImGui::GetDrawData(). This will use the SDL_Renderer provided to the interfrace with Initialize
 	// to draw the contents of the draw data to the screen.
 	void Render(ImDrawData* drawData);
-};
+}


### PR DESCRIPTION
My compiler with `-Wpedantic` complains when there's a semicolon after a namespace's closing brace.

Also, when I saved the files, Atom automatically added a newline to the end of the two files, and removed two trailing spaces. Both of those changes seem good, so I decided to keep them.