### PR TITLE
Restore renderer state after rendering

### DIFF
--- a/imgui_sdl.cpp
+++ b/imgui_sdl.cpp
@@ -556,6 +556,15 @@ namespace ImGuiSDL
 		SDL_GetRenderDrawBlendMode(CurrentDevice->Renderer, &blendMode);
 		SDL_SetRenderDrawBlendMode(CurrentDevice->Renderer, SDL_BLENDMODE_BLEND);
 
+		Uint8 initialR, initialG, initialB, initialA;
+		SDL_GetRenderDrawColor(CurrentDevice->Renderer, &initialR, &initialG, &initialB, &initialA);
+
+		SDL_bool initialClipEnabled = SDL_RenderIsClipEnabled(CurrentDevice->Renderer);
+		SDL_Rect initialClipRect;
+		SDL_RenderGetClipRect(CurrentDevice->Renderer, &initialClipRect);
+
+		SDL_Texture* initialRenderTarget = SDL_GetRenderTarget(CurrentDevice->Renderer);
+
 		ImGuiIO& io = ImGui::GetIO();
 
 		for (int n = 0; n < drawData->CmdListsCount; n++)
@@ -654,6 +663,13 @@ namespace ImGuiSDL
 		}
 
 		CurrentDevice->DisableClip();
+
+		SDL_SetRenderTarget(CurrentDevice->Renderer, initialRenderTarget);
+
+		SDL_RenderSetClipRect(CurrentDevice->Renderer, initialClipEnabled ? &initialClipRect : nullptr);
+
+		SDL_SetRenderDrawColor(CurrentDevice->Renderer,
+			initialR, initialG, initialB, initialA);
 
 		SDL_SetRenderDrawBlendMode(CurrentDevice->Renderer, blendMode);
 	}


### PR DESCRIPTION
This should fix https://github.com/Tyyppi77/imgui_sdl/issues/8.

In theory, it would be possible to keep track of whether these things have been modified, and only save/restore what's necessary, but I don't know if it's worth the extra complexity.