### PR TITLE
+Added a function to reset cached triangles.

### DIFF
--- a/example.cpp
+++ b/example.cpp
@@ -39,6 +39,8 @@ int main()
 				{
 					io.DisplaySize.x = static_cast<float>(e.window.data1);
 					io.DisplaySize.y = static_cast<float>(e.window.data2);
+
+					ImGuiSDL::Reset();
 				}
 			}
 			else if (e.type == SDL_MOUSEWHEEL)

--- a/imgui_sdl.cpp
+++ b/imgui_sdl.cpp
@@ -93,6 +93,13 @@ namespace
 
 			Clean();
 		}
+
+		void Clear()
+		{
+			Order.clear();
+			Container.clear();
+		}
+
 	private:
 		void Clean()
 		{
@@ -672,5 +679,11 @@ namespace ImGuiSDL
 			initialR, initialG, initialB, initialA);
 
 		SDL_SetRenderDrawBlendMode(CurrentDevice->Renderer, blendMode);
+	}
+
+	void Reset()
+	{
+		CurrentDevice->UniformColorTriangleCache.Clear();
+		CurrentDevice->GenericTriangleCache.Clear();
 	}
 }

--- a/imgui_sdl.h
+++ b/imgui_sdl.h
@@ -14,4 +14,7 @@ namespace ImGuiSDL
 	// Call this every frame after ImGui::Render with ImGui::GetDrawData(). This will use the SDL_Renderer provided to the interfrace with Initialize
 	// to draw the contents of the draw data to the screen.
 	void Render(ImDrawData* drawData);
+
+	// Call this on device reset to clear triangle cache.
+	void Reset();
 }


### PR DESCRIPTION
Hi,

ImGuiSDL works pretty good on my desktop with an nVidia GPU, but there's an issue on my laptop with a low end Intel HD GPU.

Everything is fine when the program just starts, until I resize the window, all triangles and bullets went vanished.

Before:

![image](https://user-images.githubusercontent.com/2062224/76296430-1825eb00-62f1-11ea-9f47-8117357559fe.png)

After resizing:

![image](https://user-images.githubusercontent.com/2062224/76296411-13613700-62f1-11ea-8d74-7252437ba4e8.png)

This PR is to fix this issue by adding a `Reset()` function to clear all cached triangles after a device reset event (window resizing).
